### PR TITLE
Allow non-0-based indices, and remove constraints

### DIFF
--- a/Sources/FisherYates/Fisher-Yates_Shuffle.swift
+++ b/Sources/FisherYates/Fisher-Yates_Shuffle.swift
@@ -8,10 +8,10 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if swift(>=2.2) && !swift(>=3.0)
+#if !swift(>=3.0)
     public typealias Collection = CollectionType
+    public typealias MutableCollection = MutableCollectionType
 #endif
-
 
 public extension Collection {
     func shuffled() -> [Iterator.Element] {
@@ -21,35 +21,36 @@ public extension Collection {
     }
 }
 
+#if !swift(>=4.0)
+    private extension MutableCollection {
+        mutating func swapAt(_ i: Index, _ j: Index) {
+            guard i != j else { return }
+            swap(&self[i], &self[j])
+        }
+    }
+#endif
+
 #if swift(>=3.0)
-    public extension MutableCollection where Self: RandomAccessCollection, IndexDistance == Int {
+    public extension MutableCollection where Self: RandomAccessCollection {
         mutating func shuffle() {
-            guard !isEmpty else { return }
-            
-            for n in 0 ..< count - 1 {
-                let i = index(startIndex, offsetBy: n)
-                let j = index(i, offsetBy: random(count - n))
-                
-                guard i != j else { continue }
-                #if swift(>=4.0)
-                    swapAt(i, j)
-                #else
-                    swap(&self[i], &self[j])
-                #endif
+            var n = count
+            while n > 1 {
+                let i = index(startIndex, offsetBy: count - n)
+                let j = index(i, offsetBy: random(n))
+                swapAt(i, j)
+                n -= 1
             }
         }
     }
 #else
-    public extension MutableCollectionType where Index: RandomAccessIndexType, Index.Distance == Int {
+    public extension MutableCollection where Index: RandomAccessIndexType {
         mutating func shuffle() {
-            guard !isEmpty else { return }
-            
-            for n in 0 ..< count - 1 {
-                let i = startIndex.advancedBy(n)
-                let j = i.advancedBy(random(count - n))
-                
-                guard i != j else { continue }
-                swap(&self[i], &self[j])
+            var n = count
+            while n > 1 {
+                let i = startIndex.advancedBy(count - n)
+                let j = i.advancedBy(random(n))
+                swapAt(i, j)
+                n -= 1
             }
         }
     }

--- a/Sources/FisherYates/Fisher-Yates_Shuffle.swift
+++ b/Sources/FisherYates/Fisher-Yates_Shuffle.swift
@@ -45,7 +45,7 @@ public extension Collection {
             guard !isEmpty else { return }
             
             for n in 0 ..< count - 1 {
-                let i = startIndex.advancedBy(
+                let i = startIndex.advancedBy(n)
                 let j = i.advancedBy(random(count - n))
                 
                 guard i != j else { continue }

--- a/Sources/FisherYates/Fisher-Yates_Shuffle.swift
+++ b/Sources/FisherYates/Fisher-Yates_Shuffle.swift
@@ -21,37 +21,30 @@ public extension Collection {
     }
 }
 
+public extension MutableCollection {
+    mutating func shuffle() {
+        var n = count
+        
+        while n > 1 {
+            #if swift(>=3.0)
+                let i = index(startIndex, offsetBy: count - n)
+                let j = index(i, offsetBy: random(n))
+            #else
+                let i = startIndex.advancedBy(count - n)
+                let j = i.advancedBy(random(n))
+            #endif
+            
+            swapAt(i, j)
+            n -= 1
+        }
+    }
+}
+
 #if !swift(>=4.0)
     private extension MutableCollection {
         mutating func swapAt(_ i: Index, _ j: Index) {
             guard i != j else { return }
             swap(&self[i], &self[j])
-        }
-    }
-#endif
-
-#if swift(>=3.0)
-    public extension MutableCollection where Self: RandomAccessCollection {
-        mutating func shuffle() {
-            var n = count
-            while n > 1 {
-                let i = index(startIndex, offsetBy: count - n)
-                let j = index(i, offsetBy: random(n))
-                swapAt(i, j)
-                n -= 1
-            }
-        }
-    }
-#else
-    public extension MutableCollection where Index: RandomAccessIndexType {
-        mutating func shuffle() {
-            var n = count
-            while n > 1 {
-                let i = startIndex.advancedBy(count - n)
-                let j = i.advancedBy(random(n))
-                swapAt(i, j)
-                n -= 1
-            }
         }
     }
 #endif

--- a/Sources/FisherYates/Fisher-Yates_Shuffle.swift
+++ b/Sources/FisherYates/Fisher-Yates_Shuffle.swift
@@ -10,13 +10,7 @@
 
 #if swift(>=2.2) && !swift(>=3.0)
     public typealias Collection = CollectionType
-
-    public protocol MutableCollection: MutableCollectionType {
-        associatedtype IndexDistance
-    }
-    extension Array: MutableCollection {
-        public typealias IndexDistance = Int
-    }
+    public typealias MutableCollection: MutableCollectionType
 #endif
 
 
@@ -28,14 +22,25 @@ public extension Collection {
     }
 }
 
-
-public extension MutableCollection where Index == Int, IndexDistance == Int {
+#if swift(>=3.0)
+public extension MutableCollection where Self: RandomAccessCollection, IndexDistance == Int {
+#else
+public extension MutableCollection where Index: RandomAccessIndexType, Index.Distance == Int {
+#endif
     mutating func shuffle() {
-        guard count > 1 else { return }
+        guard !isEmpty else { return }
 
-        for i in 0..<count - 1 {
-            let j = random(count - i) + i
+        for n in 0 ..< count - 1 {
+            #if swift(>=3.0)
+                let i = index(startIndex, offsetBy: n)
+                let j = index(i, offsetBy: random(count - n))
+            #else
+                let i = startIndex.advancedBy(n)
+                let j = i.advancedBy(random(count - n))
+            #endif
+            
             guard i != j else { continue }
+            
             #if swift(>=4.0)
                 swapAt(i, j)
             #else

--- a/Sources/FisherYates/Fisher-Yates_Shuffle.swift
+++ b/Sources/FisherYates/Fisher-Yates_Shuffle.swift
@@ -8,11 +8,6 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if !swift(>=3.0)
-    public typealias Collection = CollectionType
-    public typealias MutableCollection = MutableCollectionType
-#endif
-
 public extension Collection {
     func shuffled() -> [Iterator.Element] {
         var array = Array(self)
@@ -23,28 +18,14 @@ public extension Collection {
 
 public extension MutableCollection {
     mutating func shuffle() {
+        var i = startIndex
         var n = count
         
         while n > 1 {
-            #if swift(>=3.0)
-                let i = index(startIndex, offsetBy: count - n)
-                let j = index(i, offsetBy: random(n))
-            #else
-                let i = startIndex.advancedBy(count - n)
-                let j = i.advancedBy(random(n))
-            #endif
-            
+            let j = index(i, offsetBy: random(n))
             swapAt(i, j)
             n -= 1
+            formIndex(after: &i)
         }
     }
 }
-
-#if !swift(>=4.0)
-    private extension MutableCollection {
-        mutating func swapAt(_ i: Index, _ j: Index) {
-            guard i != j else { return }
-            swap(&self[i], &self[j])
-        }
-    }
-#endif

--- a/Sources/FisherYates/Fisher-Yates_Shuffle.swift
+++ b/Sources/FisherYates/Fisher-Yates_Shuffle.swift
@@ -24,8 +24,8 @@ public extension MutableCollection {
         while n > 1 {
             let j = index(i, offsetBy: random(n))
             swapAt(i, j)
-            n -= 1
             formIndex(after: &i)
+            n -= 1
         }
     }
 }

--- a/Sources/FisherYates/Fisher-Yates_Shuffle.swift
+++ b/Sources/FisherYates/Fisher-Yates_Shuffle.swift
@@ -10,7 +10,6 @@
 
 #if swift(>=2.2) && !swift(>=3.0)
     public typealias Collection = CollectionType
-    public typealias MutableCollection: MutableCollectionType
 #endif
 
 
@@ -23,29 +22,35 @@ public extension Collection {
 }
 
 #if swift(>=3.0)
-public extension MutableCollection where Self: RandomAccessCollection, IndexDistance == Int {
-#else
-public extension MutableCollection where Index: RandomAccessIndexType, Index.Distance == Int {
-#endif
-    mutating func shuffle() {
-        guard !isEmpty else { return }
-
-        for n in 0 ..< count - 1 {
-            #if swift(>=3.0)
+    public extension MutableCollection where Self: RandomAccessCollection, IndexDistance == Int {
+        mutating func shuffle() {
+            guard !isEmpty else { return }
+            
+            for n in 0 ..< count - 1 {
                 let i = index(startIndex, offsetBy: n)
                 let j = index(i, offsetBy: random(count - n))
-            #else
-                let i = startIndex.advancedBy(n)
-                let j = i.advancedBy(random(count - n))
-            #endif
-            
-            guard i != j else { continue }
-            
-            #if swift(>=4.0)
-                swapAt(i, j)
-            #else
-                swap(&self[i], &self[j])
-            #endif
+                
+                guard i != j else { continue }
+                #if swift(>=4.0)
+                    swapAt(i, j)
+                #else
+                    swap(&self[i], &self[j])
+                #endif
+            }
         }
     }
-}
+#else
+    public extension MutableCollectionType where Index: RandomAccessIndexType, Index.Distance == Int {
+        mutating func shuffle() {
+            guard !isEmpty else { return }
+            
+            for n in 0 ..< count - 1 {
+                let i = startIndex.advancedBy(
+                let j = i.advancedBy(random(count - n))
+                
+                guard i != j else { continue }
+                swap(&self[i], &self[j])
+            }
+        }
+    }
+#endif

--- a/Sources/FisherYates/random.swift
+++ b/Sources/FisherYates/random.swift
@@ -8,24 +8,16 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if swift(>=4.0)
-    public typealias RandomInteger = BinaryInteger
-#elseif swift(>=3.0)
-    public typealias RandomInteger = IntegerArithmetic
-#else
-    public typealias RandomInteger = IntegerArithmeticType
-#endif
-
-#if os(OSX)
+#if os(macOS)
     import Darwin
 
-    public func random<T: RandomInteger> (_ n: T) -> T {
-        numericCast(arc4random_uniform(numericCast(n)))
+    public func random<T: BinaryInteger> (_ n: T) -> T {
+        numericCast( arc4random_uniform( numericCast(n) ) )
     }
 #else
     import Glibc
 
-    public func random<T: RandomInteger> (_ n: T) -> T {
+    public func random<T: BinaryInteger> (_ n: T) -> T {
         precondition(n > 0)
      
         let upperLimit = RAND_MAX - RAND_MAX % numericCast(n)

--- a/Sources/FisherYates/random.swift
+++ b/Sources/FisherYates/random.swift
@@ -26,7 +26,7 @@
     import Glibc
 
     public func random<T: RandomInteger> (_ n: T) -> T {
-        guard n > 0 else { return 0 }
+        precondition(n > 0)
      
         let upperLimit = RAND_MAX - RAND_MAX % numericCast(n)
      

--- a/Sources/FisherYates/random.swift
+++ b/Sources/FisherYates/random.swift
@@ -8,18 +8,26 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if swift(<=3.0)
+    typealias SignedInteger = _SignedIntegerType
+#elseif swift(<=4.0)
+    typealias SignedInteger = _SignedInteger
+#endif
+
 #if os(OSX)
     import Darwin
 
-    public let random: (Int) -> Int = { Int(arc4random_uniform(UInt32($0))) }
+    public let random<T: SignedInteger>: (T) -> T = {
+        numericCast(arc4random_uniform(numericCast($0)))
+    }
 #else
     import Glibc
 
-    public let random: (Int) -> Int = {
+    public let random<T: SignedInteger>: (T) -> T = {
+        let upperLimit = RAND_MAX - RAND_MAX % numericCast($0)
         while true {
-            let x = Glibc.random() % $0
-            let y = Glibc.random() % $0
-            guard x == y else { return x }
+            let x = Glibc.random()
+            if x < upperLimit { return numericCast(x) % $0 }
         }
     }
 #endif

--- a/Sources/FisherYates/random.swift
+++ b/Sources/FisherYates/random.swift
@@ -8,12 +8,12 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if swift(<=3.0)
-    public typealias RandomInteger = IntegerArithmeticType
-#elseif swift(<=3.1)
+#if swift(>=4.0)
+    public typealias RandomInteger = BinaryInteger
+#elseif swift(>=3.0)
     public typealias RandomInteger = IntegerArithmetic
 #else
-    public typealias RandomInteger = BinaryInteger
+    public typealias RandomInteger = IntegerArithmeticType
 #endif
 
 #if os(OSX)

--- a/Sources/FisherYates/random.swift
+++ b/Sources/FisherYates/random.swift
@@ -19,17 +19,17 @@
 #if os(OSX)
     import Darwin
 
-    public let random<T: RandomInteger>: (T) -> T = {
-        numericCast(arc4random_uniform(numericCast($0)))
+    public func random<T: RandomInteger> (_ n: T) -> T {
+        numericCast(arc4random_uniform(numericCast(n)))
     }
 #else
     import Glibc
 
-    public let random<T: RandomInteger>: (T) -> T = {
-        let upperLimit = RAND_MAX - RAND_MAX % numericCast($0)
+    public func random<T: RandomInteger> (_ n: T) -> T {
+        let upperLimit = RAND_MAX - RAND_MAX % numericCast(n)
         while true {
             let x = Glibc.random()
-            if x < upperLimit { return numericCast(x) % $0 }
+            if x < upperLimit { return numericCast(x) % n }
         }
     }
 #endif

--- a/Sources/FisherYates/random.swift
+++ b/Sources/FisherYates/random.swift
@@ -9,21 +9,23 @@
 */
 
 #if swift(<=3.0)
-    typealias SignedInteger = _SignedIntegerType
-#elseif swift(<=4.0)
-    typealias SignedInteger = _SignedInteger
+    public typealias RandomInteger = IntegerArithmeticType
+#elseif swift(<=3.1)
+    public typealias RandomInteger = IntegerArithmetic
+#else
+    public typealias RandomInteger = BinaryInteger
 #endif
 
 #if os(OSX)
     import Darwin
 
-    public let random<T: SignedInteger>: (T) -> T = {
+    public let random<T: RandomInteger>: (T) -> T = {
         numericCast(arc4random_uniform(numericCast($0)))
     }
 #else
     import Glibc
 
-    public let random<T: SignedInteger>: (T) -> T = {
+    public let random<T: RandomInteger>: (T) -> T = {
         let upperLimit = RAND_MAX - RAND_MAX % numericCast($0)
         while true {
             let x = Glibc.random()

--- a/Sources/FisherYates/random.swift
+++ b/Sources/FisherYates/random.swift
@@ -12,7 +12,7 @@
     import Darwin
 
     public func random<T: BinaryInteger> (_ n: T) -> T {
-        numericCast( arc4random_uniform( numericCast(n) ) )
+        return numericCast( arc4random_uniform( numericCast(n) ) )
     }
 #else
     import Glibc

--- a/Sources/FisherYates/random.swift
+++ b/Sources/FisherYates/random.swift
@@ -26,7 +26,10 @@
     import Glibc
 
     public func random<T: RandomInteger> (_ n: T) -> T {
+        guard n > 0 else { return 0 }
+     
         let upperLimit = RAND_MAX - RAND_MAX % numericCast(n)
+     
         while true {
             let x = Glibc.random()
             if x < upperLimit { return numericCast(x) % n }


### PR DESCRIPTION
shuffle() will no longer fail when used on collections whose indices are not zero-based (eg. ArraySlice).

shuffle() now works on any MutableCollection, running in O(n) on a RandomAccessCollection and O(n^2) otherwise.

random(_) is now generic over integer types, and the Glibc version no longer exhibits modulo bias.