### PR TITLE
Fix issue with random() on Linux

### DIFF
--- a/Sources/FisherYates/random.swift
+++ b/Sources/FisherYates/random.swift
@@ -18,8 +18,7 @@
     public let random: (Int) -> Int = {
         while true {
             let x = Glibc.random() % $0
-            let y = Glibc.random() % $0
-            guard x == y else { return x }
+            if x < (RAND_MAX - RAND_MAX % Int32($0)) { return x % $0 }
         }
     }
 #endif


### PR DESCRIPTION
`random()`, as it is used currently, is also susceptible to modulo bias, so corrections must be made to ensure that it is fair. For more discussion, see [this thread](https://lists.swift.org/pipermail/swift-users/Week-of-Mon-20171211/006760.html) on swift-users.

As a side note, I haven't actually tested this by running it on Linux, so while it compiles it may have bugs.