### PR TITLE
Add support for SwiftWasm

### DIFF
--- a/Sources/FisherYates/random.swift
+++ b/Sources/FisherYates/random.swift
@@ -30,6 +30,21 @@ public func random<T: BinaryInteger> (_ n: T) -> T {
   }
 }
 
+#elseif canImport(WASILibc)
+
+import WASILibc
+
+public func random<T: BinaryInteger> (_ n: T) -> T {
+  precondition(n > 0)
+
+  let upperLimit = RAND_MAX - RAND_MAX % numericCast(n)
+
+  while true {
+    let x = WASILibc.random()
+    if x < upperLimit { return numericCast(x) % n }
+  }
+}
+
 #else
 #error("unsupported platform")
 #endif


### PR DESCRIPTION
Use [WASILibc](https://book.swiftwasm.org/getting-started/libc.html) module for `random` when running in SwiftWasm.

## How to run
- Install a recent [SwiftWasm toolchain](https://book.swiftwasm.org/getting-started/setup.html).
- Clone the Dealer package:
``` sh
git clone https://github.com/apple/example-package-dealer.git
```
- Using the SwiftWasm toolchain, build the package:
``` sh
cd example-package-dealer
swift build -c release --triple wasm32-unknown-wasi
```
- Install a runtime such as [Wasmer](https://github.com/wasmerio/wasmer-install).
- Run the WebAssembly module:
``` sh
wasmer .build/wasm32-unknown-wasi/release/Dealer.wasm
```